### PR TITLE
Compare full path of breakpoint positions.

### DIFF
--- a/src/org/jruby/debug/DebugEventHook.java
+++ b/src/org/jruby/debug/DebugEventHook.java
@@ -440,12 +440,7 @@ final class DebugEventHook extends EventHook {
             return false;
         }
         String source = debugBreakpoint.getSource().toString();
-        String sourceName = new File(source).getName();
-        String fileName = new File(file).getName();
-        if (sourceName.equals(fileName)) {
-            return true;
-        }
-        return false;
+        return new File(source).equals(new File(file));
     }
 
     private IRubyObject checkBreakpointsByMethod(DebugContext debugContext,


### PR DESCRIPTION
Fixes http://rubyforge.org/tracker/index.php?func=detail&aid=27254&group_id=3085&atid=11903
